### PR TITLE
fix two bugs in weighted branch and reduce

### DIFF
--- a/wmis/app/branch_reduce.cpp
+++ b/wmis/app/branch_reduce.cpp
@@ -93,7 +93,7 @@ int main(int argn, char **argv) {
 
         branch_and_reduce_algorithm reducer(G, mis_config);
         reducer.run_branch_reduce();
-        NodeWeight MWIS_weight = reducer.get_current_is_weight();
+        NodeWeight MWIS_weight = reducer.get_is_weight();
 
         auto end = std::chrono::system_clock::now();
 

--- a/wmis/app/weighted_ls.cpp
+++ b/wmis/app/weighted_ls.cpp
@@ -81,7 +81,7 @@ NodeWeight perform_reduction(std::unique_ptr<branch_and_reduce_algorithm>& reduc
 		exit(1);
 	}
 
-	NodeWeight is_weight = reducer->get_current_is_weight();
+	NodeWeight is_weight = reducer->get_is_weight();
 
 	return is_weight;
 }

--- a/wmis/lib/mis/kernel/branch_and_reduce_algorithm.cpp
+++ b/wmis/lib/mis/kernel/branch_and_reduce_algorithm.cpp
@@ -728,25 +728,30 @@ void branch_and_reduce_algorithm::restore_best_local_solution() {
 
 void branch_and_reduce_algorithm::restore_best_global_solution() {
 	status = std::move(global_status);
-	status.modified_queue.pop_back();
+    status.modified_queue.pop_back();
 
 	while (!status.modified_queue.empty()) {
 		NodeID node = status.modified_queue.back();
-		status.modified_queue.pop_back();
+        status.modified_queue.pop_back();
 
 		if (status.node_status[node] == IS_status::folded) {
 			auto type = status.folded_queue.back();
-			status.folded_queue.pop_back();
-			status.reductions[global_reduction_map[type]]->apply(this);
+            status.folded_queue.pop_back();
+            status.reductions[global_reduction_map[type]]->apply(this);
 		}
 		else {
-			status.graph.restore_node(node);
+            status.graph.restore_node(node);
 		}
 	}
 }
 
 NodeWeight branch_and_reduce_algorithm::get_current_is_weight() const {
 	return global_status.is_weight + global_status.reduction_offset;
+}
+
+NodeWeight branch_and_reduce_algorithm::get_is_weight() const {
+    // after restoring global best solution, global status was moved to status
+    return status.is_weight + status.reduction_offset;
 }
 
 void branch_and_reduce_algorithm::build_global_graph_access() {

--- a/wmis/lib/mis/kernel/branch_and_reduce_algorithm.h
+++ b/wmis/lib/mis/kernel/branch_and_reduce_algorithm.h
@@ -194,6 +194,8 @@ private:
 	void disable_cout();
 	void enable_cout();
 
+    NodeWeight get_current_is_weight() const;
+
 public:
 	branch_and_reduce_algorithm(graph_access& G, const MISConfig& config, bool called_from_fold = false);
 
@@ -203,7 +205,7 @@ public:
 	static size_t run_ils(const MISConfig& config, graph_access& G, sized_vector<NodeID>& tmp_buffer, size_t max_swaps);
 	static void greedy_initial_is(graph_access& G, sized_vector<NodeID>& tmp_buffer);
 
-	NodeWeight get_current_is_weight() const;
+	NodeWeight get_is_weight() const;
 	void reverse_reduction(graph_access & G, graph_access & reduced_G, std::vector<NodeID> & reverse_mapping);
 	void apply_branch_reduce_solution(graph_access & G);
 


### PR DESCRIPTION
1. fix bug in the use of get_current_is_weight() after calling restore_global_best_solution(): latter moves global_status to status but get_current_is_weight uses global_status; fixed it by introducing public method get_is_weight() and making get_current_is_weight() private
2. fix bug in fold reductions; they added the wrong solution weight to is_weight; introduced additional invariants (assertions) to ensure the correctness of the modified solution weight 

Note: Bug 2 became visible when fixing bug 1 in the final MIS weight.